### PR TITLE
Update to the Coq-8.9.1

### DIFF
--- a/README
+++ b/README
@@ -3,7 +3,7 @@ PREREQUISITES
 
 This version is known to compile with:
 
- - Coq 8.6.1
+ - Coq 8.7.2
  - SCons 3.0.1
  - Ocaml 4.05
  - GNU C preprocessor 8.3.0

--- a/README
+++ b/README
@@ -3,7 +3,7 @@ PREREQUISITES
 
 This version is known to compile with:
 
- - Coq 8.7.2
+ - Coq 8.8.2
  - SCons 3.0.1
  - Ocaml 4.05
  - GNU C preprocessor 8.3.0

--- a/README
+++ b/README
@@ -3,10 +3,10 @@ PREREQUISITES
 
 This version is known to compile with:
 
- - Coq 8.5pl2
- - SCons 2.5
- - Ocaml 4.02.3
- - GNU C preprocessor 6.1.1
+ - Coq 8.6.1
+ - SCons 3.0.1
+ - Ocaml 4.05
+ - GNU C preprocessor 8.3.0
  
 BUILDING INSTRUCTIONS
 ---------------------

--- a/README
+++ b/README
@@ -3,7 +3,7 @@ PREREQUISITES
 
 This version is known to compile with:
 
- - Coq 8.8.2
+ - Coq 8.9.1
  - SCons 3.0.1
  - Ocaml 4.05
  - GNU C preprocessor 8.3.0

--- a/abstract_c/architecture_spec.v
+++ b/abstract_c/architecture_spec.v
@@ -52,7 +52,7 @@ Program Instance arch_rank_finite {A} : Finite (arch_rank A) := {
   enum := ARank <$> enum c_rank
 }.
 Next Obligation. by intros; apply (bool_decide_unpack _). Qed.
-Next Obligation. by intros ? []; apply (bool_decide_unpack _). Qed.
+Next Obligation. by intros ? [rank]; apply (bool_decide_unpack _); destruct rank. Qed.
 
 Section architecture.
 Context (A : architecture).

--- a/abstract_c/frontend_sound.v
+++ b/abstract_c/frontend_sound.v
@@ -960,7 +960,7 @@ Proof.
     destruct (to_fun_stmt_typed S2 S3 f (xτs.*1) (xτs.*2) τ cs s)
       as (cmτ&?&?&?&?&?&?); rewrite ?fmap_length; eauto; weaken.
     edestruct (λ sto, insert_fun_valid S3 S' f sto
-      (xτs.*2) τ (Some s)); auto; weaken; eauto 20. }
+      (xτs.*2) τ (Some s)); eauto; weaken; eauto 20. }
   error_proceed [] as S3; error_proceed s as S4.
   destruct (insert_fun_None_valid S2 S3 f sto (xτs.*2) τ)
     as (?&?&?); auto; weaken.

--- a/abstract_c/natural_type_environment.v
+++ b/abstract_c/natural_type_environment.v
@@ -205,7 +205,7 @@ Proof.
       { clear Ht Hlen. unfold natural_fields_align.
         induction IH as [|τ τs IHτ ? IH]; decompose_Forall; simpl; [done|].
         rewrite Nat.lcm_eq_0; intros [|?]; [|by destruct IH].
-        by apply natural_align_ne_0. }
+        by apply (natural_align_ne_0 Γ τ). }
       destruct c; [|by apply natural_padding_divide].
       clear Ht Hτs IH. unfold field_sizes; simpl. revert Hne_0.
       generalize (natural_fields_align Γ τs); intros whole_align ?.

--- a/abstract_c/natural_type_environment.v
+++ b/abstract_c/natural_type_environment.v
@@ -138,7 +138,8 @@ Lemma natural_size_of_base Γ τb :
     end%BT.
 Proof. done. Qed.
 Lemma natural_size_of_array Γ τ n : size_of Γ (τ.[n]) = n * size_of Γ τ.
-Proof. unfold size_of; simpl. by apply type_iter_array. Qed.
+Proof. unfold size_of; simpl; unfold natural_size_of.
+  by apply type_iter_array. Qed.
 Lemma natural_size_of_compound Γ c t τs :
   ✓ Γ → Γ !! t = Some τs → size_of Γ (compoundT{c} t) =
     match c with

--- a/axiomatic/assertions.v
+++ b/axiomatic/assertions.v
@@ -794,7 +794,7 @@ Proof.
   * intros Γ1 Δ δ' ρ n ??????? (a&v&?&?&?&?&?).
     destruct (mem_singleton_union_rev Γ1 Δ m a μ γ1 γ2 v τ)
       as (m1&m2&->&?&?&?); auto.
-    exists m1, m2; split_ands; solve ltac:eauto.
+    exists m1, m2; split_ands; solve ltac:(eauto).
   * intros Γ1 Δ δ' ρ n ??????? (?&?&->&?&(a1&v1&?&?&?&?&?)&(a2&v2&?&?&?&?&?));
       simplify_equality'; exists a1, v1; eauto 10 using mem_singleton_union.
 Qed.

--- a/axiomatic/axiomatic_statements.v
+++ b/axiomatic/axiomatic_statements.v
@@ -58,7 +58,8 @@ Lemma ax_stmt_weaken Γ δ R R' J J' T T' C C' P P' Q Q' s :
   Q ⊆{Γ,δ} Q' →
   Γ\ δ\ R\ J\ T\ C ⊨ₛ {{ P }} s {{ Q }} →
   Γ\ δ\ R'\ J'\ T'\ C' ⊨ₛ {{ P' }} s {{ Q' }}.
-Proof. intros until 7. by apply ax_stmt_weaken_packed; intros []; simpl. Qed.
+Proof. intros until 7.
+  by apply ax_stmt_weaken_packed; intros []; simpl; auto; intros []. Qed.
 Lemma ax_stmt_weaken_pre Γ δ R J T C P P' Q s :
   P' ⊆{Γ,δ} P →
   Γ\ δ\ R\ J\ T\ C ⊨ₛ {{ P }} s {{ Q }} →
@@ -551,7 +552,8 @@ Proof.
   intros Δ''' n''' ? mf S' ??? (?&?&?) p _; subst; inv_rcstep p; clear S'.
   * rewrite mem_unlock_union, <-mem_unlock_all_spec by solve_elem_of.
     eapply mk_ax_next with Δ''' (mem_unlock_all _); eauto.
-    { split; by rewrite <-?mem_unlock_all_disjoint_le by auto. }
+    { split. by rewrite <-?mem_unlock_all_disjoint_le; auto.
+             by rewrite <-?mem_unlock_all_disjoint_le; auto. }
     { apply cmap_union_valid_2; auto using mem_unlock_all_valid.
       by rewrite <-sep_disjoint_list_double, <-mem_unlock_all_disjoint_le. }
     eapply ax_compose_cons;
@@ -576,7 +578,8 @@ Proof.
     apply ax_done; constructor; eauto using assert_weaken; esolve_elem_of.
   * rewrite mem_unlock_union, <-mem_unlock_all_spec by solve_elem_of.
     eapply mk_ax_next with Δ''' (mem_unlock_all _); eauto.
-    { split; by rewrite <-?mem_unlock_all_disjoint_le by auto. }
+    { split. by rewrite <-?mem_unlock_all_disjoint_le by auto.
+             by rewrite <-?mem_unlock_all_disjoint_le by auto. }
     { apply cmap_union_valid_2; auto using mem_unlock_all_valid.
       by rewrite <-sep_disjoint_list_double, <-mem_unlock_all_disjoint_le. }
     eapply ax_compose_cons;

--- a/core_c/expression_eval.v
+++ b/core_c/expression_eval.v
@@ -221,12 +221,12 @@ Proof.
   by destruct e using @expr_ind_alt; simpl;
     repeat match goal with
     | H : ⟦ _ ⟧ _ _ _ = _ |- _ => rewrite H
-    | H : appcontext [ptr_alive'] |- _ => rewrite ptr_alive_erase' in H
-    | H : appcontext [base_val_branchable] |- _ => rewrite base_val_branchable_erase in H
-    | H : appcontext [val_unop_ok] |- _ => rewrite val_unop_ok_erase in H
-    | H : appcontext [val_binop_ok] |- _ => rewrite val_binop_ok_erase in H
-    | H : appcontext [val_cast_ok] |- _ => rewrite val_cast_ok_erase in H
-    | H : appcontext [mem_forced] |- _ => rewrite mem_forced_erase in H
+    | H : context [ptr_alive'] |- _ => rewrite ptr_alive_erase' in H
+    | H : context [base_val_branchable] |- _ => rewrite base_val_branchable_erase in H
+    | H : context [val_unop_ok] |- _ => rewrite val_unop_ok_erase in H
+    | H : context [val_binop_ok] |- _ => rewrite val_binop_ok_erase in H
+    | H : context [val_cast_ok] |- _ => rewrite val_cast_ok_erase in H
+    | H : context [mem_forced] |- _ => rewrite mem_forced_erase in H
     | _ => apply option_bind_ext_fun; intros
     | _ => case_option_guard; try done
     | _ => rewrite mem_lookup_erase

--- a/core_c/expressions.v
+++ b/core_c/expressions.v
@@ -394,7 +394,7 @@ Section is_pure_ind.
   Context (Pinsert : ∀ r e1 e2,
      is_pure e1 → P e1 → is_pure e2 → P e2 → P (#[r:=e1] e2)).
   Definition is_pure_ind_alt: ∀ e, is_pure e → P e.
-  Proof. fix 2; destruct 1; eauto using Forall_impl. Qed.
+  Proof. fix H'2 2; destruct 1; eauto using Forall_impl. Qed.
 End is_pure_ind.
 
 Instance is_pure_dec {K} : ∀ e : expr K, Decision (is_pure e).

--- a/core_c/smallstep.v
+++ b/core_c/smallstep.v
@@ -294,15 +294,15 @@ This tactic is useful to automatically perform reductions, as for example
 *)
 Ltac quote_stmt s :=
   lazymatch s with
-  | ! ?e => constr:[subst (! □) e]
-  | ret ?e => constr:[subst (ret □) e]
-  | ?s1 ;; ?s2 => constr:[subst (s1 ;; □) s2; subst (□ ;; s2) s1]
-  | loop ?s => constr:[subst (loop □) s]
-  | catch ?s => constr:[subst (catch □) s]
+  | ! ?e => constr:([subst (! □) e])
+  | ret ?e => constr:([subst (ret □) e])
+  | ?s1 ;; ?s2 => constr:([subst (s1 ;; □) s2; subst (□ ;; s2) s1])
+  | loop ?s => constr:([subst (loop □) s])
+  | catch ?s => constr:([subst (catch □) s])
   | if{?e} ?s1 else ?s2 =>
-    constr:[subst (if{e} s1 else □) s2;
-            subst (if{e} □ else s2) s1; subst (if{□} s1 else s2) e]
-  | switch{?e} ?s => constr:[subst (switch{e} □) s; subst (switch{□} s) e]
+    constr:([subst (if{e} s1 else □) s2;
+            subst (if{e} □ else s2) s1; subst (if{□} s1 else s2) e])
+  | switch{?e} ?s => constr:([subst (switch{e} □) s; subst (switch{□} s) e])
   end.
 
 (** The [quote_expr e] tactic yields a list of possible ways to write an

--- a/core_c/type_system.v
+++ b/core_c/type_system.v
@@ -145,7 +145,7 @@ Section expr_typed_ind.
     Γ ⊢ r : τ ↣ σ → (Γ,Δ,τs) ⊢ e1 : inr σ → P e1 (inr σ) →
     (Γ,Δ,τs) ⊢ e2 : inr τ → P e2 (inr τ) → P (#[r:=e1]e2) (inr τ)).
   Lemma expr_typed_ind : ∀ e τ, expr_typed' Γ Δ τs e τ → P e τ.
-  Proof. fix 3; destruct 1; eauto using Forall2_impl. Qed.
+  Proof. fix H'3 3; destruct 1; eauto using Forall2_impl. Qed.
 End expr_typed_ind.
 
 Inductive ectx_item_typed' (Γ : env K) (Δ : memenv K)

--- a/core_c/type_system_decidable.v
+++ b/core_c/type_system_decidable.v
@@ -19,11 +19,12 @@ Proof.
      | inleft (exist σ _) => cast_if (decide (cast_typed σ τ1))
      | inright _ => right _
      end
-  end; abstract first
+  end; repeat first
     [ by subst; econstructor; eauto using binop_type_of_sound
     | by inversion 1; repeat match goal with
       | H : binop_typed _ _ _ _ |- _ => apply binop_type_of_complete in H
-      end; simplify_equality'].
+      end; simplify_equality'
+    | destruct τ1 | destruct τ2 ].
 Defined.
 Global Instance lrval_type_check:
    TypeCheck (env K * memenv K) (lrtype K) (lrval K) := λ ΓΔ ν,

--- a/memory/aliasing.v
+++ b/memory/aliasing.v
@@ -123,7 +123,7 @@ Proof.
   inversion Ha1 as [o1 r1 i1 τ1 σp1];
     inversion Ha2 as [o2 r2 i2 τ2 σp2]; intros; simplify_equality'.
   destruct (decide (o1 = o2)); [simplify_type_equality|by do 2 left].
-  destruct (ref_disjoint_cases Γ τ2 r1 r2 σp1 σp2)
+  destruct (ref_disjoint_cases Γ τ1 r1 r2 σp1 σp2)
     as [?|[?|[?|(s&r1'&i1'&r2'&i2'&r'&->&->&?)]]]; auto.
   * left; intros j1 j2; right; left; split; simpl; auto.
   * do 3 right; split; [done|]. by eexists s, r1', i1', r2', i2', r'.

--- a/memory/memory.v
+++ b/memory/memory.v
@@ -796,6 +796,7 @@ Proof.
   intros ?? Ha ? (w2&?&Hw2) ? (w1&?&Hw1). red. unfold insertE, mem_insert.
   destruct Ha as [<-|?]; [|erewrite cmap_lookup_alter_disjoint
     by eauto using of_val_flatten_unshared; eauto].
+  simplify_equality.
   assert (ctree_Forall (λ γb, Some Writable ⊆ pbit_kind γb)
     (of_val Γ (tagged_perm <$> ctree_flatten w2) v2)).
   { erewrite ctree_flatten_of_val by eauto. generalize (val_flatten Γ v2).

--- a/memory/memory_trees.v
+++ b/memory/memory_trees.v
@@ -137,7 +137,7 @@ Section operations.
       P (MUnionAll t γbs) (unionT t)).
     Definition ctree_typed_ind : ∀ w τ, ctree_typed' Γ Δ w τ → P w τ.
     Proof.
-      fix 3; destruct 1; simplify_equality';
+      fix H'3 3; destruct 1; simplify_equality';
         eauto using Forall2_impl, Forall_impl.
     Qed.
   End ctree_typed_ind.
@@ -206,7 +206,7 @@ Section operations.
       P (MStruct t wγbss)).
     Context (Punion_bits : ∀ t γbs, P (MUnionAll t γbs)).
     Definition union_free_ind_alt: ∀ w, union_free w → P w.
-    Proof. fix 2; destruct 1; eauto using Forall_impl. Qed.
+    Proof. fix H'2 2; destruct 1; eauto using Forall_impl. Qed.
   End union_free_ind.
   Global Instance union_free_dec: ∀ w : mtree K, Decision (union_free w).
   Proof.

--- a/memory/values.v
+++ b/memory/values.v
@@ -182,7 +182,7 @@ Section operations.
       vals_representable Γ Δ vs τs → P (VUnionAll t vs) (unionT t)).
     Definition val_typed_ind : ∀ v τ, val_typed' Γ Δ v τ → P v τ.
     Proof.
-      fix 3; destruct 1; simplify_equality;
+      fix H'3 3; destruct 1; simplify_equality;
         eauto using Forall_impl, Forall2_impl.
     Qed.
   End val_typed_ind.
@@ -340,7 +340,7 @@ Section operations.
     Context (Punion_none : ∀ t vs,
       Forall val_union_free vs → Forall P vs → P (VUnionAll t vs)).
     Definition val_union_free_ind_alt: ∀ v, val_union_free v → P v.
-    Proof. fix 2; destruct 1; eauto using Forall_impl. Qed.
+    Proof. fix H'2 2; destruct 1; eauto using Forall_impl. Qed.
   End val_union_free_ind.
   Global Instance val_union_free_dec: ∀ v, Decision (val_union_free v).
   Proof.

--- a/memory_refinements/bits_refine.v
+++ b/memory_refinements/bits_refine.v
@@ -200,8 +200,8 @@ Proof.
     match goal with
     | H : bit_join ?b _ = _ |- _ => is_var b; destruct b
     | H : bit_join _ ?b = _ |- _ => is_var b; destruct b
-    | _ => case_option_guard || simplify_equality'
-    end; by constructor; auto.
+    | _ => case_option_guard || simplify_equality' || (constructor; assumption)
+    end.
 Qed.
 Lemma bits_join_refine Γ α f Δ1 Δ2 bs1 bs2 bs3 bs1' bs2' bs3' :
   bits_join bs1 bs2 = Some bs3 → bits_join bs1' bs2' = Some bs3' →

--- a/memory_refinements/memory_refine.v
+++ b/memory_refinements/memory_refine.v
@@ -378,7 +378,7 @@ Proof.
     eauto using mem_free_index_alive_ne,
       mem_free_index_alive_inv, memenv_refine_alive_l.
   * intros o3 o4 r ???. destruct (decide (o1 = o3)); simplify_equality.
-    + by destruct (mem_free_index_alive Δ2 o4).
+    + by destruct (mem_free_index_alive Δ2 o2).
     + eauto using mem_free_index_alive_ne,
         mem_free_index_alive_inv, memenv_refine_alive_r.
   * intros o3 τ ??. destruct (decide (o1 = o3)) as [->|]; eauto.

--- a/memory_refinements/memory_trees_refine.v
+++ b/memory_refinements/memory_trees_refine.v
@@ -115,7 +115,7 @@ Section ctree_refine_ind.
     P (MUnion t i w1 γbs1) (MUnionAll t γbs2) (unionT t)).
   Definition ctree_refine_ind: ∀ w1 w2 τ,
     ctree_refine' Γ α f Δ1 Δ2 w1 w2 τ → P w1 w2 τ.
-  Proof. fix 4; destruct 1; eauto using Forall2_impl, Forall3_impl. Qed.
+  Proof. fix H'4 4; destruct 1; eauto using Forall2_impl, Forall3_impl. Qed.
 End ctree_refine_ind.
 
 Section memory_trees.
@@ -208,7 +208,7 @@ Section ctree_leaf_refine.
     Forall sep_unshared γbs2 → P (MUnion t i w1 γbs1) (MUnionAll t γbs2)).
   Lemma ctree_leaf_refine_ind_alt :
      ∀ w1 w2, ctree_leaf_refine Γ α f Δ1 Δ2 w1 w2 → P w1 w2.
-  Proof. fix 3; destruct 1; eauto using Forall2_impl. Qed.
+  Proof. fix H'3 3; destruct 1; eauto using Forall2_impl. Qed.
 End ctree_leaf_refine.
 
 Lemma ctree_refine_leaf Γ α f Δ1 Δ2 w1 w2 τ :

--- a/memory_refinements/values_refine.v
+++ b/memory_refinements/values_refine.v
@@ -57,7 +57,7 @@ Section val_refine_ind.
     P (VUnion t i v1) (VUnionAll t vs2) (unionT t)).
   Definition val_refine_ind: ∀ v1 v2 τ,
     val_refine' Γ α f Δ1 Δ2 v1 v2 τ → P v1 v2 τ.
-  Proof. fix 4; destruct 1; eauto using Forall2_impl, Forall3_impl. Qed.
+  Proof. fix H'4 4; destruct 1; eauto using Forall2_impl, Forall3_impl. Qed.
 End val_refine_ind.
 
 Section values.

--- a/memory_separation/ctrees.v
+++ b/memory_separation/ctrees.v
@@ -159,7 +159,7 @@ Section operations.
       ¬(ctree_unmapped w ∧ Forall sep_unmapped xs) → P (MUnion t i w xs)).
     Context (Punion_all : ∀ t xs, Forall sep_valid xs → P (MUnionAll t xs)).
     Definition ctree_valid_ind_alt : ∀ w, ctree_valid w → P w.
-    Proof. fix 2. destruct 1; eauto using Forall_impl. Qed.
+    Proof. fix H'2 2. destruct 1; eauto using Forall_impl. Qed.
   End ctree_valid_ind.
   Global Instance ctree_valid_dec : ∀ w, Decision (ctree_valid w).
   Proof.
@@ -223,7 +223,7 @@ Section operations.
       ctree_valid w1 → ¬(ctree_unmapped w1 ∧ Forall sep_unmapped xs1) →
       P (MUnion t i w1 xs1) (MUnionAll t xs2)).
     Definition ctree_disjoint_ind_alt : ∀ w1 w2, ctree_disjoint w1 w2 → P w1 w2.
-    Proof. fix 3. destruct 1; eauto using Forall2_impl. Qed.
+    Proof. fix H'3 3. destruct 1; eauto using Forall2_impl. Qed.
   End ctree_disjoint_ind.
   Lemma ctree_disjoint_inv_l (P : ctree K A → Prop) w1 w2 :
     w1 ⊥ w2 →
@@ -318,7 +318,7 @@ Section operations.
       ctree_valid w2 → ¬(ctree_unmapped w2 ∧ Forall sep_unmapped xs2) →
       P (MUnionAll t xs1) (MUnion t i w2 xs2)).
     Definition ctree_subseteq_ind_alt : ∀ w1 w2, ctree_subseteq w1 w2 → P w1 w2.
-    Proof. fix 3; destruct 1; eauto using Forall2_impl. Qed.
+    Proof. fix H'3 3; destruct 1; eauto using Forall2_impl. Qed.
   End ctree_subseteq_ind.
   Global Instance ctree_subseteq_dec `{∀ k1 k2 : K, Decision (k1 = k2)} :
     ∀ w1 w2, Decision (w1 ⊆ w2).

--- a/parser/Main.ml
+++ b/parser/Main.ml
@@ -12,6 +12,8 @@
 #load "Extracted.cmo";;
 #load "Include.cmo";;
 
+type ml_int = int;; (* 'Extracted' defines its own 'int' type with Coq-8.8 *)
+
 open Num;;
 open Format;;
 open Extracted;;
@@ -176,7 +178,7 @@ exception Unknown_definition of Cabs.definition;;
 exception Incompatible_compound of char list * decl * decl;;
 
 type format =
-  | Format of string * int * string * string
+  | Format of string * ml_int * string * string
   | StringLit of char list
 
 let col = ref 0;;

--- a/prelude/base.v
+++ b/prelude/base.v
@@ -496,7 +496,7 @@ Arguments partial_alter _ _ _ _ _ !_ !_ / : simpl nomatch.
 collection of type [C] that contains the keys that are a member of [m]. *)
 Class Dom (M C : Type) := dom: M → C.
 Instance: Params (@dom) 3.
-Arguments dom {_} _ {_} !_ / : simpl nomatch, clear implicits.
+Arguments dom {_} _ {_} !_ / : simpl nomatch.
 
 (** The function [merge f m1 m2] should merge the maps [m1] and [m2] by
 constructing a new map whose value at key [k] is [f (m1 !! k) (m2 !! k)].*)

--- a/prelude/collections.v
+++ b/prelude/collections.v
@@ -56,7 +56,7 @@ Section simple_collection.
     split.
     * induction Xs; simpl; intros HXs; [by apply elem_of_empty in HXs|].
       setoid_rewrite elem_of_cons. apply elem_of_union in HXs. naive_solver.
-    * intros [X []]. induction 1; simpl; [by apply elem_of_union_l |].
+    * intros [X [XXs]]. induction XXs; simpl; [by apply elem_of_union_l |].
       intros. apply elem_of_union_r; auto.
   Qed.
   Lemma non_empty_singleton x : {[ x ]} ≢ ∅.

--- a/prelude/error.v
+++ b/prelude/error.v
@@ -75,9 +75,9 @@ Ltac generalize_errors :=
     try (is_var e; fail 1); generalize e;
     let x := fresh "err" in intros x in
   repeat match goal with
-  | |- appcontext[ fail ?e ] => gen_error e
-  | |- appcontext[ error_guard _ ?e ] => gen_error e
-  | |- appcontext[ error_of_option _ ?e ] => gen_error e
+  | |- context[ fail ?e ] => gen_error e
+  | |- context[ error_guard _ ?e ] => gen_error e
+  | |- context[ error_of_option _ ?e ] => gen_error e
   end.
 Tactic Notation "simplify_error_equality" :=
   repeat match goal with

--- a/prelude/finite.v
+++ b/prelude/finite.v
@@ -8,8 +8,8 @@ Class Finite A `{∀ x y : A, Decision (x = y)} := {
   NoDup_enum : NoDup enum;
   elem_of_enum x : x ∈ enum
 }.
-Arguments enum _ {_ _} : clear implicits.
-Arguments NoDup_enum _ {_ _} : clear implicits.
+Arguments enum _ {_ _}.
+Arguments NoDup_enum _ {_ _}.
 Definition card A `{Finite A} := length (enum A).
 Program Instance finite_countable `{Finite A} : Countable A := {|
   encode := λ x,

--- a/prelude/list.v
+++ b/prelude/list.v
@@ -905,7 +905,7 @@ Proof. by destruct n. Qed.
 Lemma drop_length l n : length (drop n l) = length l - n.
 Proof. revert n. by induction l; intros [|i]; f_equal'. Qed.
 Lemma drop_ge l n : length l ≤ n → drop n l = [].
-Proof. revert n. induction l; intros [|??]; simpl in *; auto with lia. Qed.
+Proof. revert n. induction l; intros [|?]; simpl in *; auto with lia. Qed.
 Lemma drop_all l : drop (length l) l = [].
 Proof. by apply drop_ge. Qed.
 Lemma drop_drop l n1 n2 : drop n1 (drop n2 l) = drop (n2 + n1) l.
@@ -2604,7 +2604,7 @@ Section fmap.
     (∀ x, f x = y) → f <$> l = replicate (length l) y.
   Proof. intros; induction l; f_equal'; auto. Qed.
   Lemma list_lookup_fmap l i : (f <$> l) !! i = f <$> (l !! i).
-  Proof. revert i. induction l; by intros [|]. Qed.
+  Proof. revert i. induction l; by (intros [|]; simpl). Qed.
   Lemma list_lookup_fmap_inv l i x :
     (f <$> l) !! i = Some x → ∃ y, x = f y ∧ l !! i = Some y.
   Proof.

--- a/prelude/numbers.v
+++ b/prelude/numbers.v
@@ -44,11 +44,11 @@ Instance nat_le_pi: ∀ x y : nat, ProofIrrel (x ≤ y).
 Proof.
   assert (∀ x y (p : x ≤ y) y' (q : x ≤ y'),
     y = y' → eq_dep nat (le x) y p y' q) as aux.
-  { fix 3. intros x ? [|y p] ? [|y' q].
+  { fix H 3. intros x ? [|y p] ? [|y' q].
     * done.
-    * clear nat_le_pi. intros; exfalso; auto with lia.
-    * clear nat_le_pi. intros; exfalso; auto with lia.
-    * injection 1. intros Hy. by case (nat_le_pi x y p y' q Hy). }
+    * clear H. intros; exfalso; auto with lia.
+    * clear H. intros; exfalso; auto with lia.
+    * injection 1. intros Hy. by case (H x y p y' q Hy). }
   intros x y p q.
   by apply (eq_dep_eq_dec (λ x y, decide (x = y))), aux.
 Qed.

--- a/prelude/option.v
+++ b/prelude/option.v
@@ -204,11 +204,11 @@ End option_union_intersection_difference.
 (** * Tactics *)
 Tactic Notation "case_option_guard" "as" ident(Hx) :=
   match goal with
-  | H : appcontext C [@mguard option _ ?P ?dec] |- _ =>
+  | H : context C [@mguard option _ ?P ?dec] |- _ =>
     change (@mguard option _ P dec) with (λ A (x : P → option A),
       match @decide P dec with left H' => x H' | _ => None end) in *;
     destruct_decide (@decide P dec) as Hx
-  | |- appcontext C [@mguard option _ ?P ?dec] =>
+  | |- context C [@mguard option _ ?P ?dec] =>
     change (@mguard option _ P dec) with (λ A (x : P → option A),
       match @decide P dec with left H' => x H' | _ => None end) in *;
     destruct_decide (@decide P dec) as Hx
@@ -232,9 +232,9 @@ Tactic Notation "simpl_option_monad" "by" tactic3(tac) :=
       assert (o = Some x') as H by tac
     | assert (o = None) as H by tac ]
   in repeat match goal with
-  | H : appcontext [@mret _ _ ?A] |- _ =>
+  | H : context [@mret _ _ ?A] |- _ =>
      change (@mret _ _ A) with (@Some A) in H
-  | |- appcontext [@mret _ _ ?A] => change (@mret _ _ A) with (@Some A)
+  | |- context [@mret _ _ ?A] => change (@mret _ _ A) with (@Some A)
   | H : context [mbind (M:=option) (A:=?A) ?f ?o] |- _ =>
     let Hx := fresh in assert_Some_None A o Hx; rewrite Hx in H; clear Hx
   | H : context [fmap (M:=option) (A:=?A) ?f ?o] |- _ =>

--- a/prelude/optionmap.v
+++ b/prelude/optionmap.v
@@ -52,7 +52,7 @@ Proof.
     apply map_eq. intros k. apply (Hlookup (Some k)).
   * intros ? [?|]. apply (lookup_empty k). done.
   * intros ? f [? t] [k|]; simpl; [|done]. apply lookup_partial_alter.
-  * intros ? f [? t] [k|] [|k']; simpl; try intuition congruence.
+  * intros ? f [? t] [k|] [|]; simpl; try intuition congruence.
     intros; apply lookup_partial_alter_ne; congruence.
   * intros ??? [??] []; simpl. apply lookup_fmap. done.
   * intros ? [[x|] m]; unfold map_to_list; simpl.

--- a/prelude/pretty.v
+++ b/prelude/pretty.v
@@ -32,7 +32,7 @@ Proof. done. Qed.
 Lemma pretty_N_go_help_irrel x acc1 acc2 s :
   pretty_N_go_help x acc1 s = pretty_N_go_help x acc2 s.
 Proof.
-  revert x acc1 acc2 s; fix 2; intros x [acc1] [acc2] s; simpl.
+  revert x acc1 acc2 s; fix H'2 2; intros x [acc1] [acc2] s; simpl.
   destruct (decide (0 < x)%N); auto.
 Qed.
 Lemma pretty_N_go_step x s :

--- a/prelude/streams.v
+++ b/prelude/streams.v
@@ -40,9 +40,9 @@ Proof. by constructor. Qed.
 Global Instance equal_equivalence : Equivalence (@equiv (stream A) _).
 Proof.
   split.
-  * now cofix; intros [??]; constructor.
-  * now cofix; intros ?? [??]; constructor.
-  * cofix; intros ??? [??] [??]; constructor; etransitivity; eauto.
+  * now cofix s; intros [??]; constructor.
+  * now cofix s; intros ?? [??]; constructor.
+  * cofix s; intros ??? [??] [??]; constructor; etransitivity; eauto.
 Qed.
 Global Instance scons_proper x : Proper ((≡) ==> (≡)) (scons x).
 Proof. by constructor. Qed.

--- a/prelude/stringmap.v
+++ b/prelude/stringmap.v
@@ -195,6 +195,6 @@ Lemma fresh_string_fresh {A} (m : stringmap A) s : m !! fresh_string m s = None.
 Proof.
   unfold fresh_string. destruct (m !! s) as [a|] eqn:Hs; [clear a Hs|done].
   generalize 0 (wf_guard 32 (fresh_string_R_wf s m) 0); revert m.
-  fix 3; intros m n [?]; simpl; unfold fresh_string_go at 1; simpl.
+  fix H'3 3; intros m n [?]; simpl; unfold fresh_string_go at 1; simpl.
   destruct (Some_dec (m !! _)) as [[??]|?]; auto.
 Qed.

--- a/prelude/tactics.v
+++ b/prelude/tactics.v
@@ -135,7 +135,7 @@ Ltac injection' H :=
 and injects equalities, and tries to contradict impossible inequalities. *)
 Ltac fold_classes :=
   repeat match goal with
-  | |- appcontext [ ?F ] =>
+  | |- context [ ?F ] =>
     progress match type of F with
     | FMap _ =>
        change F with (@fmap _ F);
@@ -153,7 +153,7 @@ Ltac fold_classes :=
   end.
 Ltac fold_classes_hyps H :=
   repeat match type of H with
-  | appcontext [ ?F ] =>
+  | context [ ?F ] =>
     progress match type of F with
     | FMap _ =>
        change F with (@fmap _ F) in H;

--- a/refinements/refinement_system.v
+++ b/refinements/refinement_system.v
@@ -162,7 +162,7 @@ Section expr_refine_ind.
     P (#[r:=e1]e1') (#[r:=e2]e2') (inr τ)).
   Lemma expr_refine_ind : ∀ e1 e2 τ,
     expr_refine' Γ τs α f Δ1 Δ2 e1 e2 τ → P e1 e2 τ.
-  Proof. fix 4; destruct 1; eauto using Forall2_impl, Forall3_impl. Qed.
+  Proof. fix H'4 4; destruct 1; eauto using Forall2_impl, Forall3_impl. Qed.
 End expr_refine_ind.
 
 Inductive ectx_item_refine' (Γ : env K) (τs: list (type K))

--- a/separation/permissions.v
+++ b/separation/permissions.v
@@ -44,7 +44,7 @@ Instance option_pkind_subseteq : SubsetEq (option pkind) := λ k1 k2,
 Instance option_pkind_subseteq_dec : ∀ k1 k2 : option pkind, Decision (k1 ⊆ k2).
 Proof. intros [] []; apply _. Defined.
 Instance: PartialOrder (@subseteq (option pkind) _).
-Proof. by repeat split; repeat intros []. Qed.
+Proof. by repeat split; repeat intros []; try destruct p; try destruct p0; try destruct p1. Qed.
 
 Definition perm_kind (γ : perm) : option pkind :=
   match γ with

--- a/separation/separation.v
+++ b/separation/separation.v
@@ -79,7 +79,7 @@ Class Separation (A : sType) `{SeparationOps A} : Prop := {
     sep_unshared x ↔ sep_valid x ∧ ∀ y, x ⊥ y → sep_unmapped y;
   sep_unshared_unmapped (x : A) : sep_unshared x → sep_unmapped x → False
 }.
-Arguments sep_inhabited _ {_ _} : clear implicits.
+Arguments sep_inhabited _ {_ _}.
 
 (** We define a relation [xs1 ≡⊥ xs2] that states that lists [xs1] and [xs2]
 behave equivalently with respect to disjointness. For example, we have


### PR DESCRIPTION
This patch series brings ch2o up-to-date with Coq-8.9.1 (via 8.6.1, 8.7.2, and 8.8.2).
I've made sure that building the library with `scons` works for each version, is there anything else that should be tested?