### PR TITLE
Fix OCaml 4.02.3 build issue on macOS with Xcode 12

### DIFF
--- a/README
+++ b/README
@@ -8,6 +8,11 @@ This version is known to compile with:
  - Ocaml 4.02.3
  - GNU C preprocessor 6.1.1
  
+Note: when building OCaml 4.02.3 from source on macOS with Xcode 12 or
+newer, run
+
+    ./configure -cc "gcc -Wno-error=implicit-function-declaration"
+
 BUILDING INSTRUCTIONS
 ---------------------
 


### PR DESCRIPTION
[Since Xcode 12](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes), Clang reports an error instead of a warning when a function is used without a declaration. This breaks the OCaml 4.02.3 configure script, causing it to think the platform does not have sockets. This in turn causes `inet_addr_of_string` to fail, which in turn causes `ocamlbuild` to fail, which causes the CH2O build to fail.

Apart from this issue, I was able to build CH2O with Coq 8.5pl2 (.dmg release), SCons 2.5 (source), and OCaml 4.02.3 (built from source) today on macOS Big Sur with no problems. I could also run the `ch2o` tool with the Clang 12 C preprocessor after applying https://github.com/co-dan/ch2o/commit/3c9846687c01c4bfd0890b7efac58655de333ed7 .